### PR TITLE
Remove transpile step

### DIFF
--- a/nextjs/README.md
+++ b/nextjs/README.md
@@ -25,9 +25,8 @@ This is an example integration of [Friendly Captcha](https://friendlycaptcha.com
 
 ## Tips for integrating Friendly Captcha into your own project
 
-### Set up a transpile plugin
-
-The [friendly-challenge](https://github.com/friendlycaptcha/friendly-challenge) library is exported as an ES module. To make Next.js understand it we install a plugin:
+### Set up a transpile plugin (Next JS 11 and below only)
+The [friendly-challenge](https://github.com/friendlycaptcha/friendly-challenge) library is exported as an ES module. To make Next.js 11 and below understand it we install a plugin:
 
 - Install `next-transpile-modules`
   ```shell
@@ -41,8 +40,6 @@ The [friendly-challenge](https://github.com/friendlycaptcha/friendly-challenge) 
 
   module.exports = withTM({});
   ```
-
-> Next.JS 12 and later will support ES Modules without plugins, so in the future this step may not be necessary.
 
 ### Supporting very old browsers
 

--- a/nextjs/next.config.js
+++ b/nextjs/next.config.js
@@ -1,3 +1,0 @@
-// See the documentation at https://github.com/martpie/next-transpile-modules
-const withTM = require("next-transpile-modules")(["friendly-challenge"]);
-module.exports = withTM({});

--- a/nextjs/package-lock.json
+++ b/nextjs/package-lock.json
@@ -7,7 +7,6 @@
       "dependencies": {
         "friendly-challenge": "0.9.9",
         "next": "13.0.4",
-        "next-transpile-modules": "10.0.0",
         "react": "18.2.0",
         "react-dom": "18.2.0"
       }
@@ -272,18 +271,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/enhanced-resolve": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/friendly-challenge": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/friendly-challenge/-/friendly-challenge-0.9.9.tgz",
@@ -302,11 +289,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/friendly-pow/-/friendly-pow-0.2.2.tgz",
       "integrity": "sha512-oTGCqr6d9iIv8TEWmqJK8p1Gkr9hDEgb7g22pTCDZz+Y9zaaWtCNxmrD+/+KIYbf1/64rgba5Vj4hU7AxE/vkA=="
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -385,14 +367,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next-transpile-modules": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-10.0.0.tgz",
-      "integrity": "sha512-FyeJ++Lm2Fq31gbThiRCrJlYpIY9QaI7A3TjuhQLzOix8ChQrvn5ny4MhfIthS5cy6+uK1AhDRvxVdW17y3Xdw==",
-      "dependencies": {
-        "enhanced-resolve": "^5.10.0"
       }
     },
     "node_modules/object-assign-polyfill": {
@@ -497,14 +471,6 @@
         "babel-plugin-macros": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/tslib": {
@@ -652,15 +618,6 @@
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.26.1.tgz",
       "integrity": "sha512-VVXcDpp/xJ21KdULRq/lXdLzQAtX7+37LzpyfFM973il0tWSsDEoyzG38G14AjTpK9VTfiNM9jnFauq/CpaWGQ=="
     },
-    "enhanced-resolve": {
-      "version": "5.12.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz",
-      "integrity": "sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==",
-      "requires": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.2.0"
-      }
-    },
     "friendly-challenge": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/friendly-challenge/-/friendly-challenge-0.9.9.tgz",
@@ -679,11 +636,6 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/friendly-pow/-/friendly-pow-0.2.2.tgz",
       "integrity": "sha512-oTGCqr6d9iIv8TEWmqJK8p1Gkr9hDEgb7g22pTCDZz+Y9zaaWtCNxmrD+/+KIYbf1/64rgba5Vj4hU7AxE/vkA=="
-    },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -727,14 +679,6 @@
         "postcss": "8.4.14",
         "styled-jsx": "5.1.0",
         "use-sync-external-store": "1.2.0"
-      }
-    },
-    "next-transpile-modules": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/next-transpile-modules/-/next-transpile-modules-10.0.0.tgz",
-      "integrity": "sha512-FyeJ++Lm2Fq31gbThiRCrJlYpIY9QaI7A3TjuhQLzOix8ChQrvn5ny4MhfIthS5cy6+uK1AhDRvxVdW17y3Xdw==",
-      "requires": {
-        "enhanced-resolve": "^5.10.0"
       }
     },
     "object-assign-polyfill": {
@@ -804,11 +748,6 @@
       "requires": {
         "client-only": "0.0.1"
       }
-    },
-    "tapable": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
-      "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ=="
     },
     "tslib": {
       "version": "2.4.1",

--- a/nextjs/package.json
+++ b/nextjs/package.json
@@ -8,7 +8,6 @@
   "dependencies": {
     "friendly-challenge": "0.9.9",
     "next": "13.0.4",
-    "next-transpile-modules": "10.0.0",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   }


### PR DESCRIPTION
This removes the transpile build step from the example. It's no longer necessary in NextJS 12 and 13. 
It does keep the instructions in the README for those who are still on older versions.